### PR TITLE
[codex] Add release note bodies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Determine version
         id: vars
@@ -208,9 +210,21 @@ jobs:
           echo "intel_url=${intel_url}" >> "${GITHUB_OUTPUT}"
           echo "intel_sha=${intel_sha}" >> "${GITHUB_OUTPUT}"
 
+      - name: Write release notes
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+          ARM_URL: ${{ steps.metadata.outputs.arm_url }}
+          ARM_SHA: ${{ steps.metadata.outputs.arm_sha }}
+          INTEL_URL: ${{ steps.metadata.outputs.intel_url }}
+          INTEL_SHA: ${{ steps.metadata.outputs.intel_sha }}
+        run: |
+          set -euo pipefail
+          ./scripts/write-release-notes.sh release-notes.md "${VERSION}" "${ARM_URL}" "${ARM_SHA}" "${INTEL_URL}" "${INTEL_SHA}"
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          body_path: release-notes.md
           files: |
             dist/*.tar.gz
             dist/*.sha256

--- a/README.md
+++ b/README.md
@@ -367,8 +367,9 @@ Active roadmap items are tracked on GitHub and currently include:
 ## Release Process
 
 - Tag the commit you want to ship with `vX.Y.Z`; pushing the tag triggers the `Release` workflow.
-- The workflow re-runs formatting, clippy, and tests on Ubuntu, then builds macOS Intel (macos-12) and Apple Silicon (macos-14) binaries with `cargo build --release`.
-- Binaries are packaged as `arrowhead-<version>-<target>.tar.gz` with `bin/arrowhead` plus the project README and uploaded to the GitHub release.
+- The workflow re-runs formatting, clippy, and tests on Ubuntu, then builds macOS Intel and Apple Silicon binaries with `cargo build --release`.
+- Binaries are packaged as `arrowhead-<version>-<target>.tar.gz` with `bin/arrowhead`, `bin/arrowheadd`, and the project README.
+- The GitHub release body includes install instructions, artifact SHA256 sums, and conventional-commit changelog notes since the previous tag.
 - Set a personal access token with `repo` scope as the `HOMEBREW_TAP_TOKEN` repository secret so the workflow can push tap updates to `totocaster/homebrew-tap`.
 - The tap formula is rewritten automatically to point at the new release URLs and SHA256 sums for both macOS architectures.
 

--- a/scripts/write-release-notes.sh
+++ b/scripts/write-release-notes.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 6 ]]; then
+  echo "Usage: $0 <output-file> <version> <arm-url> <arm-sha> <intel-url> <intel-sha>" >&2
+  exit 1
+fi
+
+OUTPUT_FILE="$1"
+VERSION="$2"
+ARM_URL="$3"
+ARM_SHA="$4"
+INTEL_URL="$5"
+INTEL_SHA="$6"
+
+REPOSITORY="${GITHUB_REPOSITORY:-totocaster/arrowhead}"
+TAG_NAME="${ARROWHEAD_RELEASE_TAG:-${GITHUB_REF_NAME:-v${VERSION}}}"
+PREVIOUS_TAG="${ARROWHEAD_PREVIOUS_TAG:-}"
+
+if [[ -z "${PREVIOUS_TAG}" ]]; then
+  PREVIOUS_TAG="$(git describe --tags --abbrev=0 "${TAG_NAME}^" 2>/dev/null || true)"
+fi
+
+if [[ -n "${PREVIOUS_TAG}" ]]; then
+  RANGE="${PREVIOUS_TAG}..${TAG_NAME}"
+  CHANGELOG_URL="https://github.com/${REPOSITORY}/compare/${PREVIOUS_TAG}...${TAG_NAME}"
+else
+  RANGE="${TAG_NAME}"
+  CHANGELOG_URL="https://github.com/${REPOSITORY}/commits/${TAG_NAME}"
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+features="${TMP_DIR}/features.md"
+fixes="${TMP_DIR}/fixes.md"
+docs="${TMP_DIR}/docs.md"
+maintenance="${TMP_DIR}/maintenance.md"
+other="${TMP_DIR}/other.md"
+
+touch "${features}" "${fixes}" "${docs}" "${maintenance}" "${other}"
+
+while IFS=$'\t' read -r sha subject; do
+  [[ -n "${sha}" && -n "${subject}" ]] || continue
+
+  short_sha="${sha:0:7}"
+  entry="- ${subject} ([${short_sha}](https://github.com/${REPOSITORY}/commit/${sha}))"
+
+  case "${subject}" in
+    feat:*|feat\(*|feature:*|feature\(*)
+      printf '%s\n' "${entry}" >> "${features}"
+      ;;
+    fix:*|fix\(*)
+      printf '%s\n' "${entry}" >> "${fixes}"
+      ;;
+    docs:*|docs\(*)
+      printf '%s\n' "${entry}" >> "${docs}"
+      ;;
+    chore:*|chore\(*|ci:*|ci\(*|build:*|build\(*|test:*|test\(*|refactor:*|refactor\(*|perf:*|perf\(*)
+      printf '%s\n' "${entry}" >> "${maintenance}"
+      ;;
+    *)
+      printf '%s\n' "${entry}" >> "${other}"
+      ;;
+  esac
+done < <(git log --no-merges --format='%H%x09%s' "${RANGE}")
+
+append_section() {
+  local title="$1"
+  local file="$2"
+
+  if [[ -s "${file}" ]]; then
+    {
+      printf '\n### %s\n\n' "${title}"
+      cat "${file}"
+    } >> "${OUTPUT_FILE}"
+  fi
+}
+
+cat > "${OUTPUT_FILE}" <<EOF
+## Install
+
+\`\`\`sh
+brew tap totocaster/tap
+brew install totocaster/tap/arrowhead
+arrowhead --version
+\`\`\`
+
+## Highlights
+
+\`arrowhead\` is a cross-platform CLI and daemon for indexing Obsidian and Markdown vaults. It keeps full-text, semantic, hybrid, graph, notes, and MCP discovery tools ready for local CLIs and AI agents.
+
+This release archive includes both \`arrowhead\` and \`arrowheadd\`.
+
+## macOS Artifacts
+
+| Platform | Archive | SHA256 |
+| --- | --- | --- |
+| Apple Silicon | [arrowhead-${VERSION}-aarch64-apple-darwin.tar.gz](${ARM_URL}) | \`${ARM_SHA}\` |
+| Intel | [arrowhead-${VERSION}-x86_64-apple-darwin.tar.gz](${INTEL_URL}) | \`${INTEL_SHA}\` |
+
+## Changelog
+EOF
+
+append_section "Features" "${features}"
+append_section "Fixes" "${fixes}"
+append_section "Documentation" "${docs}"
+append_section "Maintenance" "${maintenance}"
+append_section "Other Changes" "${other}"
+
+cat >> "${OUTPUT_FILE}" <<EOF
+
+**Full Changelog**: ${CHANGELOG_URL}
+EOF


### PR DESCRIPTION
## Summary

- Add `scripts/write-release-notes.sh` to generate tagged release bodies with install instructions, Arrowhead highlights, artifact checksums, grouped conventional-commit changelog entries, and a full compare link.
- Wire the Release workflow to fetch tag history, generate `release-notes.md`, and publish it via `softprops/action-gh-release` `body_path`.
- Update the README release-process notes to describe the richer GitHub release body and the packaged `arrowheadd` binary.

## Why

Arrowhead releases previously uploaded artifacts without the richer release body already used in `tp7cli`. This keeps the tag-driven release output useful for users installing from Homebrew or downloading macOS archives directly.

## Verification

- `bash -n scripts/write-release-notes.sh`
- Local release-notes dry run against `v0.11.0`
- Workflow YAML parse with Ruby `YAML.load_file`
- `cargo fmt --all`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets -- --nocapture`

`actionlint` was not installed locally, so it was not run.